### PR TITLE
fix: TagsFilterCards pesquisa por tag permanece com texto global

### DIFF
--- a/src/components/organisms/TagsFilterCards.vue
+++ b/src/components/organisms/TagsFilterCards.vue
@@ -116,6 +116,7 @@ const clearFilter = () => {
       key-id="search-tag-filter"
       placeholder="Pesquisar tag"
       class="search"
+      :init-content="props.textFilterTags"
       @emit-content="(v: string) => emit('searchTag', v)"
     />
 


### PR DESCRIPTION
	modified:   src/components/organisms/TagsFilterCards.vue